### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
   "name": "codex-team/capella",
   "description": "Useful package for image uploading with capella.pics",
-  "version": "1.0.0",
   "type": "library",
   "keywords": ["image", "uploading", "filters", "uploader", "capella", "codex"],
   "homepage": "https://github.com/codex-team/capella.php#readme",


### PR DESCRIPTION
Remove "version" field from composer.json

## Description
Packagist.org recommend omit version field as the easiest way to manage the package versioning